### PR TITLE
BUGFIX: Expect "Show hidden elements" checkbox to be false

### DIFF
--- a/Classes/Xclass/CMS/Backend/View/PageLayoutView.php
+++ b/Classes/Xclass/CMS/Backend/View/PageLayoutView.php
@@ -186,7 +186,7 @@ class PageLayoutView extends \TYPO3\CMS\Backend\View\PageLayoutView {
 			return parent::makeQueryArray($table, $id, $addWhere, $fieldList);
 		}
 
-		$pattern = '%^ AND colPos\\s*=\\s*-1 AND tx_gridelements_container IN \\(\\d+(,\\s*\\d+)*\\) AND tx_gridelements_columns\\s*=\\s*\\d+ AND tt_content.deleted\\s*=\\s*0%ims';
+		$pattern = '%^ AND colPos\\s*=\\s*-1 AND tx_gridelements_container IN \\(\\d+(,\\s*\\d+)*\\) AND tx_gridelements_columns\\s*=\\s*\\d+ AND (.*)tt_content.deleted\\s*=\\s*0%ims';
 		if (preg_match($pattern, $addWhere, $matches)) {
 			return parent::makeQueryArray($table, $id, $matches[0] . ' ' . $this->getLanguageRestrictionWhereClause(), $fieldList);
 		}


### PR DESCRIPTION
In case the checkbox is "false" as per user setting, an additional
list part of conditions to check hidden and start/endtime is part
of the query string. The pattern detecting grid containers needs
to reflect that.