### PR TITLE
TASK: Keep translations soting in sync with default record

### DIFF
--- a/Classes/Hooks/PageRepository/KeepContentNontranslatlableValuesInSync.php
+++ b/Classes/Hooks/PageRepository/KeepContentNontranslatlableValuesInSync.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Netlogix\Nxcondensedbelayout\Hooks\PageRepository;
+
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+use TYPO3\CMS\Frontend\Page\PageRepositoryGetRecordOverlayHookInterface;
+
+class KeepContentNontranslatlableValuesInSync implements PageRepositoryGetRecordOverlayHookInterface, SingletonInterface
+{
+    const NON_TRANSLATABLE_PROPERTIES = [
+        'tx_gridelements_children',
+        'tx_gridelements_container',
+        'tx_gridelements_columns',
+        'tx_gridelements_backend_layout',
+        'colPos',
+        'sorting'
+    ];
+
+    protected $values = [];
+
+    public function getRecordOverlay_preProcess($table, &$row, &$sys_language_content, $OLmode, PageRepository $parent)
+    {
+        if ($table !== 'tt_content') {
+            return;
+        }
+
+        $keys = self::NON_TRANSLATABLE_PROPERTIES;
+        $values = array_map(function ($propertyName) use ($row) {
+            return $row[$propertyName];
+        }, $keys);
+
+        $this->values[$row['uid']] = array_combine($keys, $values);
+    }
+
+    public function getRecordOverlay_postProcess($table, &$row, &$sys_language_content, $OLmode, PageRepository $parent)
+    {
+        if ($table !== 'tt_content' || !$this->values[$row['uid']]) {
+            return;
+        }
+
+        $row = array_merge($row, $this->values[$row['uid']]);
+        unset($this->values[$row['uid']]);
+    }
+}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -5,16 +5,7 @@ if (!defined('TYPO3_MODE')) {
 
 call_user_func(function () {
 
-	global $TYPO3_CONF_VARS;
-
-	foreach ([
-				 'tx_gridelements_children',
-				 'tx_gridelements_container',
-				 'tx_gridelements_columns',
-				 'tx_gridelements_backend_layout',
-				 'colPos',
-				 'sorting'
-			 ] as $columnName) {
+	foreach (\Netlogix\Nxcondensedbelayout\Hooks\PageRepository\KeepContentNontranslatlableValuesInSync::NON_TRANSLATABLE_PROPERTIES as $columnName) {
 
 		if (TYPO3_MODE === 'FE') {
 			$GLOBALS['TCA']['tt_content']['columns'][$columnName]['l10n_mode'] = 'exclude';
@@ -27,7 +18,10 @@ call_user_func(function () {
 
 	if (TYPO3_MODE == 'BE') {
 		// Register wizard hook to manipulate gridelements default language
-		$TYPO3_CONF_VARS['SC_OPTIONS']['cms']['db_new_content_el']['wizardItemsHook'][] = \Netlogix\Nxcondensedbelayout\Hooks\WizardItems::class;
+		$GLOBALS['TYPO3_CONF_VARS']['cms']['db_new_content_el']['wizardItemsHook'][] = \Netlogix\Nxcondensedbelayout\Hooks\WizardItems::class;
+	}
+	if (TYPO3_MODE === 'FE') {
+		$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getRecordOverlay'][] = \Netlogix\Nxcondensedbelayout\Hooks\PageRepository\KeepContentNontranslatlableValuesInSync::class;
 	}
 
 });


### PR DESCRIPTION
Those columns should be kept in sync by DataHandler when tt_content
is updated in the backend.
But on one hand, sometimes database updates don't respect the TCA
setting.
And on the other hand, "sorting" almost never is in sync, which is
the primary use case here.

Keeping sorting in sync in FE is required since that's what the BE
mode of condensedlayout does anyway.