### PR TITLE
BUGFIX: Use l18n_parent as language pointer, not l10n_source

### DIFF
--- a/Classes/Hooks/DataHandler/ProcessDatamapService.php
+++ b/Classes/Hooks/DataHandler/ProcessDatamapService.php
@@ -66,7 +66,7 @@ class ProcessDatamapService implements SingletonInterface
 				tt_content AS defaultLanguage
 				LEFT JOIN
 					tt_content AS translationOverlay
-					ON defaultLanguage.uid = translationOverlay.l10n_source
+					ON defaultLanguage.uid = translationOverlay.l18n_parent
 			SET
 				translationOverlay.tx_gridelements_backend_layout = defaultLanguage.tx_gridelements_backend_layout
 			WHERE
@@ -99,7 +99,7 @@ class ProcessDatamapService implements SingletonInterface
 		}
 		foreach ($dataHandler->datamap['tt_content'] as $newUid => $record) {
 			if (substr($newUid, 0, 3) === 'NEW' && $record['CType'] === 'shortcut' && !$record['sys_language_uid']) {
-				if ($record['l10n_source'] > 0) {
+				if ($record['l18n_parent'] > 0) {
 					unset($dataHandler->datamap['tt_content'][$newUid]);
 				} else {
 					$dataHandler->datamap['tt_content'][$newUid]['sys_language_uid'] = -1;

--- a/Classes/Install/Updates/SynchronizeContentL10nSourceWithL18nParent.php
+++ b/Classes/Install/Updates/SynchronizeContentL10nSourceWithL18nParent.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Netlogix\Nxcondensedbelayout\Install\Updates;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+class SynchronizeContentL10nSourceWithL18nParent extends AbstractUpdate
+{
+    /**
+     * @var ConnectionPool
+     */
+    protected $connectionPool;
+
+    /**
+     * @var string
+     */
+    protected $title = 'Keep tt_content.l18n_parent in sync with tt_content.l10n_source';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkForUpdate(&$description)
+    {
+        $query = $this->getQueryBuilder();
+        $exp = $query->expr();
+
+        $result = $query
+            ->count('*')
+            ->from('tt_content')
+            ->where(
+                $exp->gt('sys_language_uid', 0),
+                $exp->eq('deleted', 0),
+                $exp->neq(
+                    'l18n_parent',
+                    $query->getConnection()->quoteIdentifier('l10n_source')
+                )
+            )
+            ->execute();
+
+        $numberOfInvalidRecords = $result->fetchColumn(0);
+
+        if ($numberOfInvalidRecords === 0) {
+            return false;
+        }
+
+        $description = sprintf(
+            'There are %d tt_content records where l18n_parent doesn\'t match l10n_source.',
+            $numberOfInvalidRecords
+        );
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function performUpdate(array &$dbQueries, &$customMessage)
+    {
+        $query = $this->getQueryBuilder();
+        $exp = $query->expr();
+
+        $query
+            ->update('tt_content')
+            ->set('l10n_source', 'l18n_parent', false)
+            ->where(
+                $exp->gt('sys_language_uid', 0),
+                $exp->eq('deleted', 0),
+                $exp->neq(
+                    'l18n_parent',
+                    $query->getConnection()->quoteIdentifier('l10n_source')
+                )
+            );
+
+        $dbQueries[] = $query->getSQL();
+
+        return $query->execute();
+    }
+
+    protected function getQueryBuilder(): QueryBuilder
+    {
+        return $this->getConnectionPool()
+            ->getConnectionByName(ConnectionPool::DEFAULT_CONNECTION_NAME)
+            ->createQueryBuilder();
+    }
+
+    protected function getConnectionPool(): ConnectionPool
+    {
+        if (!$this->connectionPool) {
+            $this->connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
+        }
+        return $this->connectionPool;
+    }
+}

--- a/Classes/Xclass/CMS/Backend/View/PageLayoutView.php
+++ b/Classes/Xclass/CMS/Backend/View/PageLayoutView.php
@@ -171,7 +171,7 @@ JavaScript;
 	}
 
 	/**
-	 * Now the query gets enhanced by the "l10n_source" pointer. This results in fetching
+	 * Now the query gets enhanced by the "l18n_parent" pointer. This results in fetching
 	 * not only L=0 and L=-1 records but native foreign language records as well.
 	 *
 	 * This method mainly gets used by grid elements.
@@ -200,7 +200,7 @@ JavaScript;
 	}
 
 	/**
-	 * Now the query gets enhanced by the "l10n_source" pointer. This results in fetching
+	 * Now the query gets enhanced by the "l18n_parent" pointer. This results in fetching
 	 * not only L=0 and L=-1 records but native foreign language records as well.
 	 *
 	 * This method mainly gets used by the PageLayout itself.
@@ -224,7 +224,7 @@ JavaScript;
 		}
 
 		return parent::getContentRecordsPerColumn($table, $id, $columns,
-			'l10n_source = 0' . $this->getLanguageRestrictionWhereClause());
+			'l18n_parent = 0' . $this->getLanguageRestrictionWhereClause());
 	}
 
 	/**
@@ -276,7 +276,7 @@ JavaScript;
 	}
 
 	/**
-	 * Returns the additional where clause limiting tt_content to l10n_source
+	 * Returns the additional where clause limiting tt_content to l18n_parent
 	 * as well as a couple of langauge ids.
 	 *
 	 * @return string
@@ -290,7 +290,7 @@ JavaScript;
 			$allowedLanguages[] = (int)$languageId;
 		}
 
-		return sprintf(' AND l10n_source = 0 AND sys_language_uid IN (%s)', join(',', $allowedLanguages));
+		return sprintf(' AND l18n_parent = 0 AND sys_language_uid IN (%s)', join(',', $allowedLanguages));
 	}
 
 	/**
@@ -336,7 +336,7 @@ JavaScript;
 	 */
 	protected function allowLanguageNotificationLinesForRecord($row)
 	{
-		if ($row['l10n_source']) {
+		if ($row['l18n_parent']) {
 			return false;
 		}
 		if ($row['sys_language_uid'] !== 0) {
@@ -402,7 +402,7 @@ JavaScript;
 		$translationRows = $queryBuilder
 			->select('*')
 			->from('tt_content')
-			->where($queryBuilder->expr()->eq('l10n_source', $queryBuilder->createNamedParameter($sourceUid, \PDO::PARAM_INT)))
+			->where($queryBuilder->expr()->eq('l18n_parent', $queryBuilder->createNamedParameter($sourceUid, \PDO::PARAM_INT)))
 			->orderBy('uid', 'ASC')
 			->execute()->fetchAll();
 

--- a/Classes/Xclass/Gridelements/Backend/ItemsProcFuncs/CTypeList.php
+++ b/Classes/Xclass/Gridelements/Backend/ItemsProcFuncs/CTypeList.php
@@ -48,7 +48,7 @@ class CTypeList extends \GridElementsTeam\Gridelements\Backend\ItemsProcFuncs\CT
 		if ($considerLanguageParentDataForL10NMode) {
 			$row = $params['row'];
 
-			$languageParent = BackendUtility::getRecord('tt_content', $row['l10n_source']);
+			$languageParent = BackendUtility::getRecord('tt_content', $row['l18n_parent']);
 			if ($languageParent) {
 				foreach ($this->excludeFromLocalizationColumnNames as $columnName) {
 					$params['row'][$columnName] = $languageParent[$columnName];
@@ -81,7 +81,7 @@ class CTypeList extends \GridElementsTeam\Gridelements\Backend\ItemsProcFuncs\CT
 			return false;
 		}
 
-		if (!$row['l10n_source']) {
+		if (!$row['l18n_parent']) {
 			return false;
 		}
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,6 +20,8 @@ call_user_func(function() {
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['constructPostProcess'][] = sprintf('%s->includeJavaScript', \Netlogix\Nxcondensedbelayout\Hooks\BackendController\PositionService::class);
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \Netlogix\Nxcondensedbelayout\Hooks\DataHandler\ProcessDatamapService::class;
 	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_page.php']['getRecordOverlay'][] = \Netlogix\Nxcondensedbelayout\Hooks\PageRepository\KeepContentNontranslatlableValuesInSync::class;
+
+	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\Netlogix\Nxcondensedbelayout\Install\Updates\SynchronizeContentL10nSourceWithL18nParent::class] = \Netlogix\Nxcondensedbelayout\Install\Updates\SynchronizeContentL10nSourceWithL18nParent::class;
 });
 
 call_user_func(function() {


### PR DESCRIPTION
The field value of l18n_parent means "the record I am the translation
of", where the field value of l10n_source means "I contain corresponding
data in another language, but I'm not a translation."

The purpose of this extension is to basically have both fields in sync.
The TYPO3 so called "mixed mode", where l10n_source and l18n_parent point
to different sources, is usually neither intended nor anderstood by
editors.

In a previous commit I made use of the l10n_source field for backend
behavior because that seemd as a better fit.

This is not true because frontend behaves ot based on l10n_source but
based on l18n_parent. In fact, the l10n_source is *only* used for
mixed mode backend behavior.

This patch now switches the condensed vackend layout back to using
l18n_parent and provides an install tool update step to set those in
sync.