### PR TITLE
BUGFIX: Ignore invalid page languages

### DIFF
--- a/Classes/Xclass/CMS/Backend/View/PageLayoutView.php
+++ b/Classes/Xclass/CMS/Backend/View/PageLayoutView.php
@@ -115,6 +115,7 @@ class PageLayoutView extends \TYPO3\CMS\Backend\View\PageLayoutView
         $pageId = (int)$row['pid'];
 
         $siteLanguages = $this->translations->getAvailableTranslationsForPage($pageId);
+        $siteLanguages = \array_filter($siteLanguages);
         if (!$siteLanguages) {
             return $result;
         }


### PR DESCRIPTION
The list of languages a certain page is translated into doesn't take
into account when languages get deleted afterwards. This results in
assuming languages that no longer exist.

This patch now avoids those non-languages to being listed when rendering
tables of content translations in the condensed backend view.